### PR TITLE
open3d>0.12.0 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@
     python -u scripts/test/sim_grasp_multiple.py --num-view 1 --object_set egad --scene egad --num-rounds 100 --model ./data/networks/neugraspnet_pile_efficient.pt --resolution=64 --type neu_grasp_pn_deeper_efficient --qual-th 0.5 --max_grasp_queries_at_once 40 --result-path ./data/results/neu_grasp_egad_efficient --sim-gui
     ```
 
+### ⚠️ Note for Open3D Versions > 0.12.0
+
+To prevent potential issues such as segmentation faults or the program hanging indefinitely (often caused by OpenMP-related parallelism in Open3D), **ensure you run your scripts with the following environment variable set**:
+
+```bash
+OMP_NUM_THREADS=1 python your_script.py
+```
+
+This limits OpenMP to a single thread, which helps avoid threading conflicts, especially in multi-threaded environments or when using libraries like Open3D for TSDF integration.
+
+
 ### Acknowledgements:
 - GPG (https://github.com/atenpas/gpg)
 - Convolutional Occupancy Networks (https://github.com/autonomousvision/convolutional_occupancy_networks)


### PR DESCRIPTION
### 🛠 Fix: Prevent Open3D Hanging or Segfaults by Limiting OpenMP Threads

#### Summary
This PR updates the `README.md` to include an important note for users of Open3D (>0.12.0), where running scripts without restricting OpenMP threads can lead to:
- Segmentation faults  
- Indefinite hanging during TSDF integration or point cloud extraction

#### Changes
- Added a **recommendation** to run scripts with `OMP_NUM_THREADS=1` to ensure stable execution.

#### Why This Matters
Open3D internally uses OpenMP for parallelism. In some environments (especially multi-core systems or within containers), unrestricted thread usage can cause instability or performance issues. This small change helps users avoid difficult-to-debug crashes and improves reliability out-of-the-box.

#### How to Use
Instead of:
```bash
python your_script.py
```

Users should run:
```bash
OMP_NUM_THREADS=1 python your_script.py
```